### PR TITLE
add insight to use npm to install the library since thats not actually mentioned in docs. 

### DIFF
--- a/contracts/index.md
+++ b/contracts/index.md
@@ -16,6 +16,11 @@ contract MyContract is BaseRelayRecipient {
 }
 ```
 
+Install the library with npm before compiling. 
+```bash
+$npm i @opengsn/contracts
+```
+
 
 ### `_msgSender`, not `msg.sender`
 


### PR DESCRIPTION
solves missing dependencies 

<img width="632" alt="Screen Shot 2021-08-30 at 12 00 47 PM" src="https://user-images.githubusercontent.com/9449596/131368787-6976f9ad-7ce6-413f-b422-cf03e88b1233.png">
