### PR TITLE
docs: renamed all instances of BaseRelayRecipient to ERC2771Recipient

### DIFF
--- a/contracts/index.md
+++ b/contracts/index.md
@@ -17,12 +17,12 @@ Please bear in mind that at the time of writing, OpenGSN requires solidity versi
 
 ## Receiving a Relayed Call <a id="recipient"></a>
 
-The first step to writing a recipient is to inherit from our BaseRelayRecipient contract. If you're also inheriting from [OpenZeppelin contracts](https://github.com/OpenZeppelin/openzeppelin-contracts), such as ERC20 or ERC721, this will work just fine: adding BaseRelayRecipient to your token contracts will make them GSN-callable.
+The first step to writing a recipient is to inherit from our ERC2771Recipient contract. If you're also inheriting from [OpenZeppelin contracts](https://github.com/OpenZeppelin/openzeppelin-contracts), such as ERC20 or ERC721, this will work just fine: adding ERC2771Recipient to your token contracts will make them GSN-callable.
 
 ```solidity
-import "@opengsn/contracts/src/BaseRelayRecipient.sol";
+import "@opengsn/contracts/src/ERC2771Recipient.sol";
 
-contract MyContract is BaseRelayRecipient {
+contract MyContract is ERC2771Recipient {
     ...
 }
 ```
@@ -30,10 +30,10 @@ contract MyContract is BaseRelayRecipient {
 
 ### `_msgSender`, not `msg.sender`
 
-There's only one extra detail you need to take care of when working with GSN recipient contracts: _you must never use `msg.sender` or `msg.data` directly_. On relayed calls, `msg.sender` will be the `Forwarder` contract instead of your user! This doesn't mean however you won't be able to retrieve your users' addresses: `BaseRelayRecipient` provides `_msgSender()`, which is a drop-in replacement for `msg.sender` that takes care of the low-level details. As long as you use this function instead of the original `msg.sender`, you're good to go!
+There's only one extra detail you need to take care of when working with GSN recipient contracts: _you must never use `msg.sender` or `msg.data` directly_. On relayed calls, `msg.sender` will be the `Forwarder` contract instead of your user! This doesn't mean however you won't be able to retrieve your users' addresses: `ERC2771Recipient` provides `_msgSender()`, which is a drop-in replacement for `msg.sender` that takes care of the low-level details. As long as you use this function instead of the original `msg.sender`, you're good to go!
 
 ::: warning
-Third-party contracts you inherit from may not use these replacement functions, making them unsafe to use when mixed with `BaseRelayRecipient`. If in doubt, head on over to our [Discord support group](https://discord.gg/NXXTCbh58s).
+Third-party contracts you inherit from may not use these replacement functions, making them unsafe to use when mixed with `ERC2771Recipient`. If in doubt, head on over to our [Discord support group](https://discord.gg/NXXTCbh58s).
 :::
 ## Paying for your user's meta-transaction <a id="paymaster"></a>
 
@@ -169,7 +169,7 @@ Only use it if you write and audit both the `Paymaster` and `Recipient` and thes
 
 As your contract now seemingly allows GSN - a complicated network of third-party contracts - to handle your dapp's user authentication, you may feel worried that you will need to verify and audit every bit of the GSN as thoroughly as your own code. Worry no more!
 
-The GSN project provides you with a default implementation of the `Forwarder` contract. This contract is extremely simple and basically does just one thing - it validates the user's signature. This way, your `BaseRelayRecipient` contract is shielded from any potential vulnerabilities across the GSN.
+The GSN project provides you with a default implementation of the `Forwarder` contract. This contract is extremely simple and basically does just one thing - it validates the user's signature. This way, your `ERC2771Recipient` contract is shielded from any potential vulnerabilities across the GSN.
 
 You can read more about the security considerations in our [forwarder ERC draft](https://github.com/ethereum/EIPs/pull/2770).
 

--- a/faq/general.md
+++ b/faq/general.md
@@ -76,7 +76,7 @@ The [GSN Protocol](https://github.com/opengsn/gsn-protocol/blob/master/gsn-proto
 
 ## How does a contract know who the user is? <a id="how_do_i_know_who_the_user_is?"></a>
 
-The `BaseRelayRecipient` contract has a utility function called `_msgSender()`
+The `ERC2771Recipient` contract has a utility function called `_msgSender()`
 which returns the true address of the user making a contract call. The function
 `_msgSender()` should be used in place of the solidity system variable
 `msg.sender`.
@@ -86,7 +86,7 @@ present state. This means that for relayed transactions, `msg.sender` will
 return the address of the relay server signing the transaction, and not the
 user requesting the transaction. Contracts that use `msg.sender` are not
 natively compatible with the Gas Station network. It is necessary to use the
-`_msgSender()` function from the `BaseRelayRecipient` contract in the [*OpenGSN
+`_msgSender()` function from the `ERC2771Recipient` contract in the [*OpenGSN
 library*](../contracts/index.md) if your contract needs to identify the
 initiator of a GSN powered transaction.
 

--- a/faq/troubleshooting.md
+++ b/faq/troubleshooting.md
@@ -13,10 +13,10 @@ are used by all other contracts, and thus the hooks below are enough to support 
 ```solidity
 pragma solidity ^0.8;
 
-import "@opengsn/contracts/src/BaseRelayRecipient.sol";
+import "@opengsn/contracts/src/ERC2771Recipient.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-contract MyContract is BaseRelayRecipient, ERC20 {
+contract MyContract is ERC2771Recipient, ERC20 {
 
   constructor(string memory name_, string memory symbol_, address forwarder_) 
     ERC20(name_, symbol_) {
@@ -25,19 +25,19 @@ contract MyContract is BaseRelayRecipient, ERC20 {
 
   string public override versionRecipient = "2.2.0";
 
-  function _msgSender() internal view override(Context, BaseRelayRecipient)
+  function _msgSender() internal view override(Context, ERC2771Recipient)
       returns (address sender) {
-      sender = BaseRelayRecipient._msgSender();
+      sender = ERC2771Recipient._msgSender();
   }
 
-  function _msgData() internal view override(Context, BaseRelayRecipient)
+  function _msgData() internal view override(Context, ERC2771Recipient)
       returns (bytes memory) {
-      return BaseRelayRecipient._msgData();
+      return ERC2771Recipient._msgData();
   }
 }
 ```
 
-You can use instead OpenZeppelin's `ERC2771Context`, which is an equivalent implementation of BaseRelayRecipient.
+You can use instead OpenZeppelin's `ERC2771Context`, which is an equivalent implementation of ERC2771Recipient.
 
 ## "signature mismatch" when using Metamask with local ganache
 

--- a/javascript-client/devops.md
+++ b/javascript-client/devops.md
@@ -1,7 +1,7 @@
 # Preparing the environment
 ## Configuring your contracts <a id="configure_contracts"></a>
 
-After your contract is changed to inherit `BaseRelayRecipient`, and you are satisfied with your implementation of `BasePaymaster`, it is time to wrap it all together.
+After your contract is changed to inherit `ERC2771Recipient`, and you are satisfied with your implementation of `BasePaymaster`, it is time to wrap it all together.
 
 
 ### Configuring a [Forwarder](../contracts/index.md#trusted_forwarder)
@@ -10,7 +10,7 @@ Your Recipient will only accept relayed transactions coming from a specific dedi
 You can choose to deploy the default `Forwarder` from your Recipient's solidity code, or using the Truffle migrations or equivalent.
 
 ::: warning
-It is up to the contract with accepts relayed transactions, the one that inherits from `BaseRelayRecipient`, 
+It is up to the contract with accepts relayed transactions, the one that inherits from `ERC2771Recipient`, 
 :::
 to initialize the `trustedForwarder` field correctly.
 ### Configuring a [Paymaster](../contracts/index.md#paymaster) <a id="paymaster"></a>

--- a/javascript-client/getting-started.md
+++ b/javascript-client/getting-started.md
@@ -59,15 +59,15 @@ Or, if you like to run it together with ganache, add a script command:
 ### Add GSN to your contract <a id='add-to-contract'></a>
 When receiving a meta-transaction, a contract must be able to recognize the caller, which is usually `msg.sender`
 When receiving meta (relayed) transactions, the sender is different, so you must inherit
-a specific baseclass (BaseRelayRecipient) and use helper method `_msgSender()` to get the
+a specific baseclass (ERC2771Recipient) and use helper method `_msgSender()` to get the
 address of the sender.
 You also need have a`forwarder`, which is the contract you will receive the calls through.
 See "delpoyment" below on how to set its value.
 
 ```javascript
-import "@opengsn/contracts/src/BaseRelayRecipient";
+import "@opengsn/contracts/src/ERC2771Recipient";
 
-contract MyContract is BaseRelayRecipient {
+contract MyContract is ERC2771Recipient {
     constructor(address forwarder) {
         trustedForwarder = forwarder;
     }

--- a/javascript-client/tutorial.md
+++ b/javascript-client/tutorial.md
@@ -37,8 +37,8 @@ To accept transactions that are paid for by a separate entity you have to do sev
    ```
 1. Import the base contract, and inherit from it:
    ```javascript
-   import "@opengsn/contracts/src/BaseRelayRecipient.sol";
-   contract MyContract is BaseRelayRecipient { ... }
+   import "@opengsn/contracts/src/ERC2771Recipient.sol";
+   contract MyContract is ERC2771Recipient { ... }
    ```
 1. Create a constructor that sets `trustedForwarder` to the address of a 
    trusted forwarder. The purpose is to have a tiny (and therefore easily 
@@ -72,9 +72,9 @@ pragma solidity ^0.6.10;
 
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-import "@opengsn/contracts/src/BaseRelayRecipient.sol";
+import "@opengsn/contracts/src/ERC2771Recipient.sol";
 
-contract CaptureTheFlag is BaseRelayRecipient {
+contract CaptureTheFlag is ERC2771Recipient {
 	string public override versionRecipient = "2.0.0";
 
 	event FlagCaptured(address _from, address _to);


### PR DESCRIPTION
In commit `fb3967e3` of [opengsn/gsn](https://github.com/opengsn/gsn/tree/fb3967e3b634cd002bcdf6c5df09d7c143727260), the `BaseRelayRecipient` contract was renamed to `ERC2771Recipient`.

This PR as mentioned, renames all instances of BaseRelayRecipient to ERC2771Recipient in order to provide more clarity when reading the documentation.